### PR TITLE
Fix log in error: change two parameters of update_attributes to hash

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,7 +43,7 @@ class User < ActiveRecord::Base
 
   # Forgets a user
   def forget
-    self.update_attributes(remember_digest: nil)
+    update_attributes(remember_digest: nil)
   end
 
   # Follows a user.


### PR DESCRIPTION
Parameter of update_attributes is a hash, not two variables.